### PR TITLE
Add support for Nintendo Switch 2 games

### DIFF
--- a/AmiiboGameList/ConsoleClasses/Switch2.cs
+++ b/AmiiboGameList/ConsoleClasses/Switch2.cs
@@ -1,0 +1,21 @@
+namespace AmiiboGameList.ConsoleClasses;
+
+/// <summary>Class containing an array of Nintendo Switch 2 games</summary>
+[Serializable()]
+[System.ComponentModel.DesignerCategory("code")]
+[System.Xml.Serialization.XmlRoot("releases")]
+public class Switch2Releases
+{
+	[System.Xml.Serialization.XmlElement("release")]
+	public Switch2Game[] release;
+}
+
+/// <summary>Class for each Nintendo Switch 2 game.</summary>
+[Serializable()]
+[System.ComponentModel.DesignerCategory("code")]
+[System.Xml.Serialization.XmlType(AnonymousType = true)]
+public class Switch2Game
+{
+	public string name;
+	public string titleid;
+}

--- a/AmiiboGameList/Games.cs
+++ b/AmiiboGameList/Games.cs
@@ -13,6 +13,8 @@ public class Games
     [JsonIgnore]
     internal static Lookup<string, string> SwitchGames;
     [JsonIgnore]
+    internal static List<Switch2Game> Switch2Games;
+    [JsonIgnore]
     internal static List<string> missingGames;
 
     /// <summary>Initializes a new instance of the <see cref="Games" /> class.</summary>
@@ -21,6 +23,7 @@ public class Games
         games3DS = new();
         gamesWiiU = new();
         gamesSwitch = new();
+        gamesSwitch2 = new();
     }
 
     /// <summary>Gets or sets the games3DS.</summary>
@@ -32,6 +35,9 @@ public class Games
     /// <summary>Gets or sets the gamesSwitch.</summary>
     /// <value>The gamesSwitch.</value>
     public List<Game> gamesSwitch { get; set; }
+    /// <summary>Gets or sets the gamesSwitch2.</summary>
+    /// <value>The gamesSwitch2.</value>
+    public List<Game> gamesSwitch2 { get; set; }
 }
 /// <summary>Class to hold all data for individual game data.</summary>
 public class Game : IComparable<Game>


### PR DESCRIPTION
While adding the PR to support the Nintendo Switch 2 for AmiiboAPI, I was made aware of this project which is used to generate the json file (much better than the modifications I made by hand, obviously).

So here is support for Nintendo Switch 2.